### PR TITLE
Change option from --without-gui to --with-gui

### DIFF
--- a/install_octave.sh
+++ b/install_octave.sh
@@ -209,8 +209,8 @@ fi
 if [ "$build_devel" == "y" ]; then
 	octave_settings="$octave_settings --devel"
 fi
-if [ "$build_gui" == "n" ]; then
-	octave_settings="$octave_settings --without-gui"
+if [ "$build_gui" == "y" ]; then
+	octave_settings="$octave_settings --with-gui"
 fi
 if [ "$use_java" == "y" ]; then
 	octave_settings="$octave_settings --with-java"


### PR DESCRIPTION
At least from what I can see on the brew formula, it looks like default is now to build without a gui and you have to specifically build with "--with-gui" option. It appears this has flip flopped in the past before.

Am I correct?