### PR TITLE
Change --devel option to --HEAD

### DIFF
--- a/install_octave.sh
+++ b/install_octave.sh
@@ -207,7 +207,7 @@ if [ "$verbose" == "y" ]; then
 	octave_settings="$octave_settings --verbose"
 fi
 if [ "$build_devel" == "y" ]; then
-	octave_settings="$octave_settings --devel"
+	octave_settings="$octave_settings --HEAD"
 fi
 if [ "$build_gui" == "n" ]; then
 	octave_settings="$octave_settings --without-gui"


### PR DESCRIPTION
This is another "maybe" change I saw but couldn't confirm with successful build. Brew formula documentation suggests "--HEAD" for the developmental version and doesn't appear to support a "--devel" option.

This brings up another potential issue with the script default behavior as now by, if you try to build with a gui, you have to also have the "--HEAD" option as they dropped support for qt4, as indicated by the messages during brew install. So, technically, at least for now, it appears that having separate variables up front in the file for "devel" and "gui" can lead to unsuccessful builds for that reason. I'm not 100% sure but that what it appears like to me. Maybe you can confirm otherwise.